### PR TITLE
Add react-native.config.js to package.json/files

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -111,8 +111,8 @@ android {
     main {
       if (isNewArchitectureEnabled()) {
           java.srcDirs += [
-            "android/build/generated/source/codegen/java",
-            "android/build/generated/source/codegen/jni"
+            "generated/java",
+            "generated/jni"
           ]
       }
     }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -111,8 +111,8 @@ android {
     main {
       if (isNewArchitectureEnabled()) {
           java.srcDirs += [
-            "generated/java",
-            "generated/jni"
+            "android/build/generated/source/codegen/java",
+            "android/build/generated/source/codegen/jni"
           ]
       }
     }

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "cpp",
     "*.podspec",
     "build",
+    "react-native.config.js",
     "!ios/build",
     "!android/build",
     "!android/gradle",


### PR DESCRIPTION
Hi @Johennes.

there seems to be another way to fix https://github.com/unomed-dev/react-native-matrix-sdk/pull/11

See:

https://github.com/callstack/react-native-builder-bob/issues/647

Problem is that react-native.config.js is missing in the npm package. 

Unfortunately, it took me some time to figure out the "real" issue ...
