### PR TITLE
feat: attach binaries to github release

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,9 +1,11 @@
 {
   "env": {
-    "es6": true
+    "es6": true,
+    "node": true
   },
   "parserOptions": {
-    "sourceType": "module",
+    "ecmaVersion": 2018,
+    "sourceType": "module"
   },
   "plugins": ["prettier"]
 }

--- a/.gitignore
+++ b/.gitignore
@@ -83,3 +83,4 @@ rust_modules/
 # React Native Codegen
 ios/generated
 android/generated
+binaries.tar.gz

--- a/package.json
+++ b/package.json
@@ -138,7 +138,9 @@
     },
     "github": {
       "release": true,
-      "assets": ["binaries.tar.gz"]
+      "assets": [
+        "binaries.tar.gz"
+      ]
     },
     "hooks": {
       "before:release": "node scripts/package-binaries.js"

--- a/package.json
+++ b/package.json
@@ -24,9 +24,9 @@
     "ios",
     "cpp",
     "*.podspec",
-    "build",
     "react-native.config.js",
     "swift",
+    "scripts",
     "!ios/build",
     "!android/build",
     "!android/gradle",
@@ -59,7 +59,7 @@
     "clean": "del-cli -v android/build example/android/build example/android/app/build example/ios/build lib **/.cxx",
     "prepare": "bob build",
     "release": "release-it",
-    "postinstall": "patch-package"
+    "postinstall": "patch-package && node scripts/download-binaries.js"
   },
   "keywords": [
     "react-native",
@@ -100,6 +100,7 @@
     "react-native": "0.76.9",
     "react-native-builder-bob": "^0.31.0",
     "release-it": "^15.0.0",
+    "tar": "^7.4.3",
     "turbo": "^1.10.7",
     "typescript": "^5.2.2",
     "uniffi-bindgen-react-native": "0.29.3-1"
@@ -136,7 +137,11 @@
       "publish": true
     },
     "github": {
-      "release": true
+      "release": true,
+      "assets": ["binaries.tar.gz"]
+    },
+    "hooks": {
+      "before:release": "node scripts/package-binaries.js"
     },
     "plugins": {
       "@release-it/conventional-changelog": {

--- a/scripts/download-binaries.js
+++ b/scripts/download-binaries.js
@@ -1,0 +1,84 @@
+#!/usr/bin/env node
+
+const fs = require('fs');
+const path = require('path');
+const https = require('https');
+const { execSync } = require('child_process');
+const tar = require('tar');
+
+const PACKAGE_JSON = require('../package.json');
+const VERSION = PACKAGE_JSON.version;
+const REPO = 'unomed-dev/react-native-matrix-sdk';
+
+async function downloadFile(url, dest) {
+  return new Promise((resolve, reject) => {
+    const file = fs.createWriteStream(dest);
+    https.get(url, (response) => {
+      if (response.statusCode === 302 || response.statusCode === 301) {
+        // Follow redirect
+        https.get(response.headers.location, (redirectResponse) => {
+          redirectResponse.pipe(file);
+          file.on('finish', () => {
+            file.close(resolve);
+          });
+        }).on('error', reject);
+      } else if (response.statusCode === 200) {
+        response.pipe(file);
+        file.on('finish', () => {
+          file.close(resolve);
+        });
+      } else {
+        reject(new Error(`HTTP ${response.statusCode}`));
+      }
+    }).on('error', reject);
+  });
+}
+
+async function downloadBinaries() {
+  const buildDir = path.join(__dirname, '..', 'build');
+  
+  // Check if binaries already exist
+  if (fs.existsSync(path.join(buildDir, 'RnMatrixRustSdk.xcframework'))) {
+    console.log('Binaries already exist, skipping download.');
+    return;
+  }
+
+  console.log(`Downloading binaries for v${VERSION}...`);
+  
+  // Create build directory
+  if (!fs.existsSync(buildDir)) {
+    fs.mkdirSync(buildDir, { recursive: true });
+  }
+
+  const releaseUrl = `https://github.com/${REPO}/releases/download/v${VERSION}/binaries.tar.gz`;
+  const tempFile = path.join(buildDir, 'binaries.tar.gz');
+
+  try {
+    // Download the binary archive
+    console.log(`Downloading from ${releaseUrl}...`);
+    await downloadFile(releaseUrl, tempFile);
+    
+    // Extract the archive
+    console.log('Extracting binaries...');
+    await tar.x({
+      file: tempFile,
+      cwd: buildDir,
+    });
+    
+    // Clean up
+    fs.unlinkSync(tempFile);
+    
+    console.log('Binaries downloaded successfully!');
+  } catch (error) {
+    console.error('Failed to download binaries:', error.message);
+    console.error('You may need to build the binaries locally using:');
+    console.error('  yarn generate:release');
+    process.exit(1);
+  }
+}
+
+if (require.main === module) {
+  downloadBinaries().catch(console.error);
+}
+
+module.exports = { downloadBinaries };

--- a/scripts/download-binaries.js
+++ b/scripts/download-binaries.js
@@ -73,7 +73,8 @@ async function downloadBinaries() {
     console.error('Failed to download binaries:', error.message);
     console.error('You may need to build the binaries locally using:');
     console.error('  yarn generate:release');
-    process.exit(1);
+    // Exit gracefully if binaries do not exist
+    process.exit(0);
   }
 }
 

--- a/scripts/package-binaries.js
+++ b/scripts/package-binaries.js
@@ -1,0 +1,34 @@
+#!/usr/bin/env node
+
+const fs = require('fs');
+const path = require('path');
+const tar = require('tar');
+
+async function packageBinaries() {
+  const buildDir = path.join(__dirname, '..', 'build');
+  const outputFile = path.join(__dirname, '..', 'binaries.tar.gz');
+  
+  if (!fs.existsSync(path.join(buildDir, 'RnMatrixRustSdk.xcframework'))) {
+    console.error('No binaries found in build directory. Run yarn generate:release first.');
+    process.exit(1);
+  }
+
+  console.log('Packaging binaries...');
+  
+  await tar.c({
+    gzip: true,
+    file: outputFile,
+    cwd: buildDir,
+  }, ['.']);
+  
+  const stats = fs.statSync(outputFile);
+  const sizeMB = (stats.size / 1024 / 1024).toFixed(2);
+  
+  console.log(`Binaries packaged successfully: ${outputFile} (${sizeMB} MB)`);
+}
+
+if (require.main === module) {
+  packageBinaries().catch(console.error);
+}
+
+module.exports = { packageBinaries };

--- a/yarn.lock
+++ b/yarn.lock
@@ -3030,6 +3030,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@isaacs/fs-minipass@npm:^4.0.0":
+  version: 4.0.1
+  resolution: "@isaacs/fs-minipass@npm:4.0.1"
+  dependencies:
+    minipass: ^7.0.4
+  checksum: 5d36d289960e886484362d9eb6a51d1ea28baed5f5d0140bbe62b99bac52eaf06cc01c2bc0d3575977962f84f6b2c4387b043ee632216643d4787b0999465bf2
+  languageName: node
+  linkType: hard
+
 "@isaacs/ttlcache@npm:^1.4.1":
   version: 1.4.1
   resolution: "@isaacs/ttlcache@npm:1.4.1"
@@ -4564,6 +4573,7 @@ __metadata:
     react-native: 0.76.9
     react-native-builder-bob: ^0.31.0
     release-it: ^15.0.0
+    tar: ^7.4.3
     turbo: ^1.10.7
     typescript: ^5.2.2
     uniffi-bindgen-react-native: 0.29.3-1
@@ -5596,6 +5606,13 @@ __metadata:
   version: 2.0.0
   resolution: "chownr@npm:2.0.0"
   checksum: c57cf9dd0791e2f18a5ee9c1a299ae6e801ff58fee96dc8bfd0dcb4738a6ce58dd252a3605b1c93c6418fe4f9d5093b28ffbf4d66648cb2a9c67eaef9679be2f
+  languageName: node
+  linkType: hard
+
+"chownr@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "chownr@npm:3.0.0"
+  checksum: fd73a4bab48b79e66903fe1cafbdc208956f41ea4f856df883d0c7277b7ab29fd33ee65f93b2ec9192fc0169238f2f8307b7735d27c155821d886b84aa97aa8d
   languageName: node
   linkType: hard
 
@@ -11223,7 +11240,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minipass@npm:^5.0.0 || ^6.0.2 || ^7.0.0, minipass@npm:^7.0.2, minipass@npm:^7.0.3, minipass@npm:^7.1.2":
+"minipass@npm:^5.0.0 || ^6.0.2 || ^7.0.0, minipass@npm:^7.0.2, minipass@npm:^7.0.3, minipass@npm:^7.0.4, minipass@npm:^7.1.2":
   version: 7.1.2
   resolution: "minipass@npm:7.1.2"
   checksum: 2bfd325b95c555f2b4d2814d49325691c7bee937d753814861b0b49d5edcda55cbbf22b6b6a60bb91eddac8668771f03c5ff647dcd9d0f798e9548b9cdc46ee3
@@ -11237,6 +11254,15 @@ __metadata:
     minipass: ^3.0.0
     yallist: ^4.0.0
   checksum: f1fdeac0b07cf8f30fcf12f4b586795b97be856edea22b5e9072707be51fc95d41487faec3f265b42973a304fe3a64acd91a44a3826a963e37b37bafde0212c3
+  languageName: node
+  linkType: hard
+
+"minizlib@npm:^3.0.1":
+  version: 3.0.2
+  resolution: "minizlib@npm:3.0.2"
+  dependencies:
+    minipass: ^7.1.2
+  checksum: 493bed14dcb6118da7f8af356a8947cf1473289c09658e5aabd69a737800a8c3b1736fb7d7931b722268a9c9bc038a6d53c049b6a6af24b34a121823bb709996
   languageName: node
   linkType: hard
 
@@ -11257,6 +11283,15 @@ __metadata:
   bin:
     mkdirp: bin/cmd.js
   checksum: a96865108c6c3b1b8e1d5e9f11843de1e077e57737602de1b82030815f311be11f96f09cce59bd5b903d0b29834733e5313f9301e3ed6d6f6fba2eae0df4298f
+  languageName: node
+  linkType: hard
+
+"mkdirp@npm:^3.0.1":
+  version: 3.0.1
+  resolution: "mkdirp@npm:3.0.1"
+  bin:
+    mkdirp: dist/cjs/src/bin.js
+  checksum: 972deb188e8fb55547f1e58d66bd6b4a3623bf0c7137802582602d73e6480c1c2268dcbafbfb1be466e00cc7e56ac514d7fd9334b7cf33e3e2ab547c16f83a8d
   languageName: node
   linkType: hard
 
@@ -13861,6 +13896,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"tar@npm:^7.4.3":
+  version: 7.4.3
+  resolution: "tar@npm:7.4.3"
+  dependencies:
+    "@isaacs/fs-minipass": ^4.0.0
+    chownr: ^3.0.0
+    minipass: ^7.1.2
+    minizlib: ^3.0.1
+    mkdirp: ^3.0.1
+    yallist: ^5.0.0
+  checksum: 8485350c0688331c94493031f417df069b778aadb25598abdad51862e007c39d1dd5310702c7be4a6784731a174799d8885d2fde0484269aea205b724d7b2ffa
+  languageName: node
+  linkType: hard
+
 "temp@npm:^0.8.4":
   version: 0.8.4
   resolution: "temp@npm:0.8.4"
@@ -14890,6 +14939,13 @@ __metadata:
   version: 4.0.0
   resolution: "yallist@npm:4.0.0"
   checksum: 343617202af32df2a15a3be36a5a8c0c8545208f3d3dfbc6bb7c3e3b7e8c6f8e7485432e4f3b88da3031a6e20afa7c711eded32ddfb122896ac5d914e75848d5
+  languageName: node
+  linkType: hard
+
+"yallist@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "yallist@npm:5.0.0"
+  checksum: eba51182400b9f35b017daa7f419f434424410691bbc5de4f4240cc830fdef906b504424992700dc047f16b4d99100a6f8b8b11175c193f38008e9c96322b6a5
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Combined size of binaries is getting too big to create releases on npm. Let's attach them to github releases instead